### PR TITLE
fix: fix parsing of dotnet list package of non-english output

### DIFF
--- a/src/Core/Liz.Core.Tests/PackageReferences/DotnetCli/ParseDotnetListPackageResultTests.cs
+++ b/src/Core/Liz.Core.Tests/PackageReferences/DotnetCli/ParseDotnetListPackageResultTests.cs
@@ -119,4 +119,34 @@ public class ParseDotnetListPackageResultTests
             .Should()
             .BeEquivalentTo(expectedReferences);
     }
+    
+    [Fact]
+    // c.f.: https://github.com/wgnf/liz/issues/32
+    public void Should_Be_Able_To_Parse_Example_Output_With_A_Non_English_Output()
+    {
+        var context = new ArrangeContext<ParseDotnetListPackageResult>();
+        var sut = context.Build();
+
+        // ReSharper disable StringLiteralTypo
+        const string exampleOutput = @"Das Projekt 'SentimentAnalysis' enthält die folgenden Paketverweise.
+    [netcoreapp2.1]:
+    Paket oberster Ebene               Angefordert   Aufgelöst
+    > Microsoft.ML                     1.4.0         1.4.0
+    > Microsoft.NETCore.App   (A)      [2.1.0, )     2.1.0
+    
+    (A) : Auto-referenced package.";
+        // ReSharper restore StringLiteralTypo
+
+        var expectedReferences = new List<PackageReference>
+        {
+            new("Microsoft.ML", "netcoreapp2.1", "1.4.0"), 
+            new("Microsoft.NETCore.App", "netcoreapp2.1", "2.1.0")
+        };
+        
+        var packageReferences = sut.Parse(exampleOutput);
+
+        packageReferences
+            .Should()
+            .BeEquivalentTo(expectedReferences);
+    }
 }


### PR DESCRIPTION
## 📫 Addressed Issue(s)

- Closes #32 

## 📄 Description

This fixes the parsing of the output of `dotnet list package` of non-english output

## ✅ Checks


- [x] My PR adheres to the general code-style of this project (look at other code if you're unsure)
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the automated tests have passed

## ℹ Additional Information

- 
