### PR TITLE
fix: problem getting project references for new and old style projects

### DIFF
--- a/src/Core/Liz.Core.IntegrationTests/GetProjectReferencesTests.cs
+++ b/src/Core/Liz.Core.IntegrationTests/GetProjectReferencesTests.cs
@@ -11,7 +11,7 @@ public class GetProjectReferencesTests
     [Fact]
     public void Gets_Project_References_Of_Liz_Tool_Project_Correctly()
     {
-        const string lizToolProjectPath = "../../../../../Tool/Liz.Tool/Liz.Tool.csproj";
+        const string lizToolProjectPath = "../../../../../Tool/Liz.Tool.Tests/Liz.Tool.Tests.csproj";
         
         var fileSystem = new FileSystem();
         var lizToolProjectFile = fileSystem.FileInfo.FromFileName(lizToolProjectPath);
@@ -23,12 +23,12 @@ public class GetProjectReferencesTests
         var getProjectReferences = new GetProjectReferences(fileSystem);
 
         var lizToolProject = new Project("Liz.Tool", lizToolProjectFile, ProjectFormatStyle.SdkStyle);
-        var projectReferences = getProjectReferences.GetProjectReferenceNames(lizToolProject);
+        var projectReferences = getProjectReferences.Get(lizToolProject);
 
         projectReferences
             .Should()
-            .Contain("Liz.Core")
+            .Contain(reference => reference.Name == "Liz.Core")
             .And
-            .Contain("Liz.Tool");
+            .Contain(reference => reference.Name == "Liz.Tool");
     }
 }

--- a/src/Core/Liz.Core.Tests/PackageReferences/DotnetCli/GetPackageReferencesViaDotnetCliTests.cs
+++ b/src/Core/Liz.Core.Tests/PackageReferences/DotnetCli/GetPackageReferencesViaDotnetCliTests.cs
@@ -83,8 +83,12 @@ public class GetPackageReferencesViaDotnetCliTests
 
         context
             .For<IGetProjectReferences>()
-            .Setup(getProjectReferences => getProjectReferences.GetProjectReferenceNames(It.IsAny<Project>()))
-            .Returns(new[] { "liz.something", "liz.core.something" });
+            .Setup(getProjectReferences => getProjectReferences.Get(It.IsAny<Project>()))
+            .Returns(new[]
+            {
+                new ProjectReference("liz.something"),
+                new ProjectReference("liz.core.something")
+            });
         
         var project = new Project("Something", Mock.Of<IFileInfo>(), ProjectFormatStyle.SdkStyle);
         var result = await sut.GetFromProjectAsync(project, true);

--- a/src/Core/Liz.Core.Tests/Projects/GetProjectReferencesTests.cs
+++ b/src/Core/Liz.Core.Tests/Projects/GetProjectReferencesTests.cs
@@ -17,7 +17,7 @@ public class GetProjectReferencesTests
         var context = ArrangeContext<GetProjectReferences>.Create();
         var sut = context.Build();
 
-        Assert.Throws<ArgumentNullException>(() => sut.GetProjectReferenceNames(null!));
+        Assert.Throws<ArgumentNullException>(() => sut.Get(null!));
     }
 
     [Fact]
@@ -33,7 +33,7 @@ public class GetProjectReferencesTests
 
         var project = new Project("Something", projectFileMock.Object, ProjectFormatStyle.SdkStyle);
 
-        var result = sut.GetProjectReferenceNames(project);
+        var result = sut.Get(project);
 
         result
             .Should()
@@ -58,6 +58,7 @@ public class GetProjectReferencesTests
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include=""ProjectThree.csproj"" />
         <ProjectReference Include=""ProjectTwo.csproj"" />
     </ItemGroup>
 </Project>"));
@@ -70,6 +71,8 @@ public class GetProjectReferencesTests
 
     <ItemGroup>
         <ProjectReference Include=""ProjectThree.csproj"" />
+        <ProjectReference />
+        <ProjectReference Something=""SomethingThatDoesNotBelongHere"" />
     </ItemGroup>
 </Project>"));
         
@@ -80,14 +83,14 @@ public class GetProjectReferencesTests
         var projectOne = mockFileSystem.FileInfo.FromFileName("ProjectOne.csproj");
         var project = new Project("ProjectOne", projectOne, ProjectFormatStyle.SdkStyle);
 
-        var result = sut.GetProjectReferenceNames(project);
+        var result = sut.Get(project);
 
         result
             .Should()
-            .Contain("NameFromPackageId")
+            .Contain(reference => reference.Name == "NameFromPackageId")
             .And
-            .Contain("NameFromAssemblyName")
+            .Contain(reference => reference.Name == "NameFromAssemblyName")
             .And
-            .Contain("ProjectThree");
+            .Contain(reference => reference.Name == "ProjectThree");
     }
 }

--- a/src/Core/Liz.Core/PackageReferences/DotnetCli/GetPackageReferencesViaDotnetCli.cs
+++ b/src/Core/Liz.Core/PackageReferences/DotnetCli/GetPackageReferencesViaDotnetCli.cs
@@ -58,7 +58,9 @@ internal sealed class GetPackageReferencesViaDotnetCli : IGetPackageReferencesVi
 
     private void RemoveProjectReferencePackages(Project project, List<PackageReference> packageReferences)
     {
-        var projectReferenceNames = _getProjectReferences.GetProjectReferenceNames(project);
+        var projectReferenceNames = _getProjectReferences
+            .Get(project)
+            .Select(reference => reference.Name);
 
         foreach (var projectReferenceName in projectReferenceNames)
             packageReferences.RemoveAll(packageReference => packageReference.Name == projectReferenceName);

--- a/src/Core/Liz.Core/Projects/Contracts/IGetProjectReferences.cs
+++ b/src/Core/Liz.Core/Projects/Contracts/IGetProjectReferences.cs
@@ -4,5 +4,5 @@ namespace Liz.Core.Projects.Contracts;
 
 internal interface IGetProjectReferences
 {
-    IEnumerable<string> GetProjectReferenceNames(Project project);
+    IEnumerable<ProjectReference> Get(Project project);
 }

--- a/src/Core/Liz.Core/Projects/Contracts/Models/Project.cs
+++ b/src/Core/Liz.Core/Projects/Contracts/Models/Project.cs
@@ -1,7 +1,9 @@
-﻿using System.IO.Abstractions;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.IO.Abstractions;
 
 namespace Liz.Core.Projects.Contracts.Models;
 
+[ExcludeFromCodeCoverage] // DTO
 internal sealed record Project(string Name, IFileInfo File, ProjectFormatStyle FormatStyle)
 {
     public string Name { get; } = Name;

--- a/src/Core/Liz.Core/Projects/Contracts/Models/ProjectReference.cs
+++ b/src/Core/Liz.Core/Projects/Contracts/Models/ProjectReference.cs
@@ -1,0 +1,59 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Liz.Core.Projects.Contracts.Models;
+
+[ExcludeFromCodeCoverage] // DTO
+internal sealed class ProjectReference : IEquatable<ProjectReference>
+{
+    private readonly List<ProjectReference> _projectReferences = new();
+
+    public ProjectReference(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(name));
+
+        Name = name;
+    }
+
+    public string Name { get; }
+
+    public IEnumerable<ProjectReference> ProjectReferences => _projectReferences;
+
+    public void AddReference(ProjectReference projectReference)
+    {
+        if (projectReference == null) throw new ArgumentNullException(nameof(projectReference));
+
+        if (_projectReferences.Contains(projectReference)) return;
+        
+        _projectReferences.Add(projectReference);
+    }
+
+    public bool Equals(ProjectReference? other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        // ReSharper disable once ConvertIfStatementToReturnStatement
+        if (ReferenceEquals(this, other)) return true;
+        
+        return string.Equals(Name, other.Name, StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return ReferenceEquals(this, obj) || (obj is ProjectReference other && Equals(other));
+    }
+
+    public override int GetHashCode()
+    {
+        return StringComparer.InvariantCultureIgnoreCase.GetHashCode(Name);
+    }
+
+    public static bool operator ==(ProjectReference? left, ProjectReference? right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(ProjectReference? left, ProjectReference? right)
+    {
+        return !Equals(left, right);
+    }
+}

--- a/src/Core/Liz.Core/Projects/GetProjectReferences.cs
+++ b/src/Core/Liz.Core/Projects/GetProjectReferences.cs
@@ -1,6 +1,7 @@
 ﻿using Liz.Core.Projects.Contracts;
 using Liz.Core.Projects.Contracts.Models;
 using System.IO.Abstractions;
+using System.Xml;
 using System.Xml.Linq;
 
 namespace Liz.Core.Projects;
@@ -9,38 +10,48 @@ internal sealed class GetProjectReferences : IGetProjectReferences
 {
     private readonly IFileSystem _fileSystem;
 
+    private readonly List<ProjectReference> _projectReferencesCache = new();
+
     public GetProjectReferences(IFileSystem fileSystem)
     {
         _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
     }
     
-    public IEnumerable<string> GetProjectReferenceNames(Project project)
+    public IEnumerable<ProjectReference> Get(Project project)
     {
         if (project == null) throw new ArgumentNullException(nameof(project));
 
         var projectFile = project.File;
-        var projectReferenceNames = GetProjectReferenceNames(projectFile);
-        return projectReferenceNames.Distinct();
+        
+        var projectReference = DoGetProjectReference(projectFile);
+        var projectReferences = FlattenProjectReferences(projectReference).Distinct();
+
+        return projectReferences;
     }
 
-    private IEnumerable<string> GetProjectReferenceNames(IFileInfo projectFile)
+    private ProjectReference DoGetProjectReference(IFileInfo projectFile)
     {
-        var projectReferenceNames = new List<string>();
-
-        if (!projectFile.Exists) return projectReferenceNames;
-
         var projectFileContent = _fileSystem.File.ReadAllText(projectFile.FullName);
+        var projectReferenceName = DetermineProjectReferenceName(projectFileContent, projectFile);
 
-        var projectXml = XDocument.Parse(projectFileContent);
-        var projectReferenceName = DetermineProjectReferenceName(projectFile, projectXml);
+        // if something is in the (local class-)cache, we don't have to run the whole thing again
+        var cachedCandidate = _projectReferencesCache
+            .FirstOrDefault(reference => reference.Name == projectReferenceName);
+        if (cachedCandidate != null) return cachedCandidate;
 
-        projectReferenceNames.Add(projectReferenceName);
+        var currentProjectReference = new ProjectReference(projectReferenceName);
+        var subProjectReferenceFiles = DetermineSubProjectReferenceFiles(projectFileContent, projectFile);
 
-        GetProjectReferenceNamesFromProjectReferences(projectFile, projectXml, projectReferenceNames);
-
-        return projectReferenceNames;
+        foreach (var subProjectReferenceFile in subProjectReferenceFiles)
+        {
+            var subProjectReferences = DoGetProjectReference(subProjectReferenceFile);
+            currentProjectReference.AddReference(subProjectReferences);
+        }
+        
+        _projectReferencesCache.Add(currentProjectReference);
+        return currentProjectReference;
     }
-
+    
     /*
      * NOTE:
      * the project-name (which is later used as the package-name i.e. when doing 'dotnet list package') is one of the
@@ -51,8 +62,11 @@ internal sealed class GetProjectReferences : IGetProjectReferences
      * - XML-Element "AssemblyName"
      * - file-name
      */
-    private string DetermineProjectReferenceName(IFileSystemInfo projectFile, XContainer projectXml)
+    private string DetermineProjectReferenceName(string projectFileContent, IFileSystemInfo projectFile)
     {
+        // this somehow only works reliably using XDocument?!
+        var projectXml = XDocument.Parse(projectFileContent);
+        
         var packageId = projectXml
             .Descendants("PackageId")
             .FirstOrDefault()?
@@ -73,24 +87,62 @@ internal sealed class GetProjectReferences : IGetProjectReferences
         return projectReferenceName;
     }
 
-    private void GetProjectReferenceNamesFromProjectReferences(
-        IFileInfo projectFile, 
-        XContainer projectXml,
-        List<string> projectReferenceNames)
+    private IEnumerable<IFileInfo> DetermineSubProjectReferenceFiles(string projectFileContent, IFileInfo projectFile)
     {
-        var projectReferences = projectXml
-            .Descendants("ProjectReference")
-            .Select(element => element.Attribute("Include")?.Value)
-            .Where(projectReference => !string.IsNullOrWhiteSpace(projectReference));
+        // this somehow only works reliably using XmlDocument?!
+        var projectXml = new XmlDocument();
+        projectXml.LoadXml(projectFileContent);
+        
+        var projectReferencePaths = new List<string>();
 
-        foreach (var projectReference in projectReferences)
+        var projectReferenceNodes = projectXml.GetElementsByTagName("ProjectReference");
+        // ReSharper disable once LoopCanBeConvertedToQuery
+        foreach (XmlNode? projectReferenceNode in projectReferenceNodes)
         {
-            // the project-reference is a relative path of the current project-file
-            var projectReferencePath = _fileSystem.Path.Combine(projectFile.Directory.FullName, projectReference);
-            var projectReferenceInfo = _fileSystem.FileInfo.FromFileName(projectReferencePath);
-
-            var subProjectReferenceNames = GetProjectReferenceNames(projectReferenceInfo);
-            projectReferenceNames.AddRange(subProjectReferenceNames);
+            if (!TryGetProjectReferencePath(projectReferenceNode, out var projectReferencePath)) continue;
+            
+            projectReferencePaths.Add(projectReferencePath);
         }
+        
+        // the project-reference is a relative path of the current project-file
+        var projectReferenceFiles = projectReferencePaths
+            .Select(path => _fileSystem.Path.Combine(projectFile.Directory.FullName, path))
+            .Select(combinedPath => _fileSystem.FileInfo.FromFileName(combinedPath));
+
+        return projectReferenceFiles;
+    }
+    
+    private static bool TryGetProjectReferencePath(XmlNode? projectReferenceNode, out string projectReferencePath)
+    {
+        projectReferencePath = string.Empty;   
+        
+        var projectReferenceNodeAttributes = projectReferenceNode?.Attributes;
+        if (projectReferenceNodeAttributes == null) return false;
+
+        // ReSharper disable once LoopCanBeConvertedToQuery
+        foreach (XmlAttribute? projectReferenceAttribute in projectReferenceNodeAttributes)
+        {
+            if (projectReferenceAttribute?.Name != "Include") continue;
+                
+            projectReferencePath = projectReferenceAttribute.Value;
+            
+            // first thing we got is the only thing we need
+            return true;
+        }
+
+        return false;
+    }
+    
+    private static IEnumerable<ProjectReference> FlattenProjectReferences(ProjectReference projectReference)
+    {
+        var projectReferences = new List<ProjectReference>(new[] { projectReference });
+
+        foreach (var reference in projectReference.ProjectReferences)
+        {
+            var subReferences = FlattenProjectReferences(reference);
+            projectReferences.AddRange(subReferences);
+        }
+
+        return projectReferences;
     }
 }

--- a/src/Core/Liz.Core/Projects/GetProjectReferences.cs
+++ b/src/Core/Liz.Core/Projects/GetProjectReferences.cs
@@ -22,6 +22,7 @@ internal sealed class GetProjectReferences : IGetProjectReferences
         if (project == null) throw new ArgumentNullException(nameof(project));
 
         var projectFile = project.File;
+        if (!projectFile.Exists) return Enumerable.Empty<ProjectReference>();
         
         var projectReference = DoGetProjectReference(projectFile);
         var projectReferences = FlattenProjectReferences(projectReference).Distinct();
@@ -107,7 +108,8 @@ internal sealed class GetProjectReferences : IGetProjectReferences
         // the project-reference is a relative path of the current project-file
         var projectReferenceFiles = projectReferencePaths
             .Select(path => _fileSystem.Path.Combine(projectFile.Directory.FullName, path))
-            .Select(combinedPath => _fileSystem.FileInfo.FromFileName(combinedPath));
+            .Select(combinedPath => _fileSystem.FileInfo.FromFileName(combinedPath))
+            .Where(file => file.Exists);
 
         return projectReferenceFiles;
     }


### PR DESCRIPTION
## 📄 Description

This PR fixes an issue when getting the project-references for an SDK-Style project, which references a non-SDK-Style project

## ✅ Checks

- [x] My PR adheres to the general code-style of this project (look at other code if you're unsure)
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the automated tests have passed