### PR TITLE
fix: exclude more keywords for GPL

### DIFF
--- a/src/Core/Liz.Core.IntegrationTests/LicenseTypesTests.cs
+++ b/src/Core/Liz.Core.IntegrationTests/LicenseTypesTests.cs
@@ -16,7 +16,8 @@ public class LicenseTypesTests
     [InlineData("NetOffice.Core", "1.7.4.4", "net6.0", new[] { "MIT" })]
     [InlineData("NetOffice.Outlook", "1.7.4.4", "net6.0", new[] { "MIT" })]
     [InlineData("Microsoft.AspNet.Razor", "3.0.0", "net6.0", new[] { "MS-NETLIB" })]
-    [InlineData("YamlDotNet", "11.2.1", "net6.0", new [] { "MIT" })]
+    [InlineData("YamlDotNet", "11.2.1", "net6.0", new[] { "MIT" })]
+    [InlineData("Accord", "3.8.0", "net6.0", new[] { "LGPL-2.1" })]
     public async Task Determines_Correct_License_Types(
         string packageName,
         string packageVersion,
@@ -46,7 +47,7 @@ public class LicenseTypesTests
 
     private static string PrepareCsprojFile(
         string packageName,
-        string targetFramework, 
+        string targetFramework,
         string packageVersion)
     {
         var temporaryDirectory = Path.GetTempPath();
@@ -62,9 +63,9 @@ public class LicenseTypesTests
     <PackageReference Include=""{packageName}"" Version=""{packageVersion}"" />
   </ItemGroup>
 </Project>";
-        
+
         File.WriteAllText(temporaryProjectFile, projectFileContent);
-        
+
         return temporaryProjectFile;
     }
 
@@ -76,7 +77,7 @@ public class LicenseTypesTests
         {
             _targetFile = targetFile;
         }
-        
+
         public override string GetTargetFile()
         {
             return _targetFile;

--- a/src/Core/Liz.Core/License/Sources/LicenseType/GnuLicenseTypeDefinitionProvider.cs
+++ b/src/Core/Liz.Core/License/Sources/LicenseType/GnuLicenseTypeDefinitionProvider.cs
@@ -1,6 +1,7 @@
 ﻿using Liz.Core.License.Contracts;
 using Liz.Core.License.Contracts.Models;
 
+// ReSharper disable CommentTypo
 // ReSharper disable StringLiteralTypo
 
 namespace Liz.Core.License.Sources.LicenseType;
@@ -13,18 +14,39 @@ internal sealed class GnuLicenseTypeDefinitionProvider : ILicenseTypeDefinitionP
         {
             new LicenseTypeDefinition("GPL-1.0", "GNU GENERAL PUBLIC LICENSE", "Version 1")
             {
-                // this is part of MPL, which lists some secondary licenses...
-                ExclusiveTextSnippets = new []{ "Secondary License" }
+                ExclusiveTextSnippets = new []
+                {
+                    // this is part of MPL, which lists some secondary licenses...
+                    "Secondary License",
+                    // this is part of the LGPL
+                    "Lesser",
+                    // this is part of the AGPL
+                    "Affero"
+                }
             },
             new LicenseTypeDefinition("GPL-2.0", "GNU GENERAL PUBLIC LICENSE", "Version 2")
             {
-                // this is part of MPL, which lists some secondary licenses...
-                ExclusiveTextSnippets = new []{ "Secondary License" }
+                ExclusiveTextSnippets = new []
+                {
+                    // this is part of MPL, which lists some secondary licenses...
+                    "Secondary License",
+                    // this is part of the LGPL
+                    "Lesser",
+                    // this is part of the AGPL
+                    "Affero"
+                }
             },
             new LicenseTypeDefinition("GPL-3.0", "GNU GENERAL PUBLIC LICENSE", "Version 3")
             {
-                // this is part of MPL, which lists some secondary licenses...
-                ExclusiveTextSnippets = new []{ "Secondary License" }
+                ExclusiveTextSnippets = new []
+                {
+                    // this is part of MPL, which lists some secondary licenses...
+                    "Secondary License",
+                    // this is part of the LGPL
+                    "Lesser",
+                    // this is part of the AGPL
+                    "Affero"
+                }
             },
             new LicenseTypeDefinition("AGPL-1.0", "AFFERO GENERAL PUBLIC LICENSE", "Version 1")
             {


### PR DESCRIPTION
## 📫 Addressed Issue(s)

- Closes #113 

## 📄 Description

The problem is that the license-types `LGPL` and `AGPL` were always paired with `GPL`, because they always had the same snippet in them. These are now excluded.

## ✅ Checks

- [x] My PR adheres to the general code-style of this project (look at other code if you're unsure)
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the automated tests have passed
