### PR TITLE
fix: fix package download when CPM is enabled

### DIFF
--- a/src/Core/Liz.Core.Tests/Preparation/CheckCpmPreprocessorTests.cs
+++ b/src/Core/Liz.Core.Tests/Preparation/CheckCpmPreprocessorTests.cs
@@ -1,0 +1,258 @@
+﻿using ArrangeContext.Moq;
+using FluentAssertions;
+using Liz.Core.Logging.Contracts;
+using Liz.Core.Preparation;
+using Liz.Core.Preparation.Contracts.Models;
+using Liz.Core.Settings;
+using Moq;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using Xunit;
+
+namespace Liz.Core.Tests.Preparation;
+
+public sealed class CheckCpmPreprocessorTests
+{
+    [Fact]
+    public async Task Gets_Not_Enabled_When_No_Props_File()
+    {
+        const string targetFile = "C:/some/directory/target.file";
+        var sourceInfo = new SourceInfo();
+        var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { targetFile, new MockFileData("") }
+        });
+
+        var context = ArrangeContext<CheckCpmPreprocessor>.Create();
+        context.Use(sourceInfo);
+        context.Use<IFileSystem>(mockFileSystem);
+
+        context
+            .For<ExtractLicensesSettingsBase>()
+            .Setup(settings => settings.GetTargetFile())
+            .Returns(targetFile);
+
+        var sut = context.Build();
+
+        await sut.PreprocessAsync();
+
+        sourceInfo
+            .IsCpmEnabled
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public async Task Gets_Not_Enabled_When_No_Enabling_Element()
+    {
+        const string propsFileContent = @"
+<Project>
+    <ItemGroup>
+        <PackageVersion Include=""NewtonSoft.Json"" Version=""1.3.3"" />
+    </ItemGroup>
+</Project>";
+        
+        const string targetFile = "C:/some/directory/target.file";
+        var sourceInfo = new SourceInfo();
+        var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { targetFile, new MockFileData("") }, 
+            { "C:/some/Directory.Packages.props", new MockFileData(propsFileContent) }
+        });
+        
+        var context = ArrangeContext<CheckCpmPreprocessor>.Create();
+        context.Use(sourceInfo);
+        context.Use<IFileSystem>(mockFileSystem);
+
+        context
+            .For<ExtractLicensesSettingsBase>()
+            .Setup(settings => settings.GetTargetFile())
+            .Returns(targetFile);
+
+        var sut = context.Build();
+
+        await sut.PreprocessAsync();
+
+        sourceInfo
+            .IsCpmEnabled
+            .Should()
+            .BeFalse();
+    }
+    
+    [Fact]
+    public async Task Gets_Not_Enabled_When_Enabling_Elements_Value_Is_False()
+    {
+        const string propsFileContent = @"
+<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <PackageVersion Include=""NewtonSoft.Json"" Version=""1.3.3"" />
+    </ItemGroup>
+</Project>";
+        
+        const string targetFile = "C:/some/directory/target.file";
+        var sourceInfo = new SourceInfo();
+        var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { targetFile, new MockFileData("") }, 
+            { "C:/some/Directory.Packages.props", new MockFileData(propsFileContent) }
+        });
+        
+        var context = ArrangeContext<CheckCpmPreprocessor>.Create();
+        context.Use(sourceInfo);
+        context.Use<IFileSystem>(mockFileSystem);
+
+        context
+            .For<ExtractLicensesSettingsBase>()
+            .Setup(settings => settings.GetTargetFile())
+            .Returns(targetFile);
+
+        var sut = context.Build();
+
+        await sut.PreprocessAsync();
+
+        sourceInfo
+            .IsCpmEnabled
+            .Should()
+            .BeFalse();
+    }
+    
+    [Fact]
+    public async Task Gets_Enabled_When_Enabling_Elements_Value_Is_True()
+    {
+        const string propsFileContent = @"
+<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <PackageVersion Include=""NewtonSoft.Json"" Version=""1.3.3"" />
+    </ItemGroup>
+</Project>";
+        
+        const string targetFile = "C:/some/directory/target.file";
+        var sourceInfo = new SourceInfo();
+        var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { targetFile, new MockFileData("") }, 
+            { "C:/some/Directory.Packages.props", new MockFileData(propsFileContent) }
+        });
+        
+        var context = ArrangeContext<CheckCpmPreprocessor>.Create();
+        context.Use(sourceInfo);
+        context.Use<IFileSystem>(mockFileSystem);
+
+        context
+            .For<ExtractLicensesSettingsBase>()
+            .Setup(settings => settings.GetTargetFile())
+            .Returns(targetFile);
+
+        var sut = context.Build();
+
+        await sut.PreprocessAsync();
+
+        sourceInfo
+            .IsCpmEnabled
+            .Should()
+            .BeTrue();
+    }
+    
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Gets_Enabled_Status_From_Imported_File(bool enabledInImportedFile)
+    {
+        const string propsFileContent = @"
+<Project>
+    <Import Project=""../Directory.Packages.props""/>
+    
+    <ItemGroup>
+        <PackageVersion Include=""NewtonSoft.Json"" Version=""1.3.3"" />
+    </ItemGroup>
+</Project>";
+        
+        var importedPropsFileContent = $@"
+<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>{enabledInImportedFile}</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+</Project>";
+        
+        const string targetFile = "C:/some/directory/target.file";
+        var sourceInfo = new SourceInfo();
+        var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { targetFile, new MockFileData("") }, 
+            { "C:/some/Directory.Packages.props", new MockFileData(propsFileContent) },
+            { "C:/Directory.Packages.props", new MockFileData(importedPropsFileContent) }
+        });
+        
+        var context = ArrangeContext<CheckCpmPreprocessor>.Create();
+        context.Use(sourceInfo);
+        context.Use<IFileSystem>(mockFileSystem);
+
+        context
+            .For<ExtractLicensesSettingsBase>()
+            .Setup(settings => settings.GetTargetFile())
+            .Returns(targetFile);
+
+        var sut = context.Build();
+
+        await sut.PreprocessAsync();
+
+        sourceInfo
+            .IsCpmEnabled
+            .Should()
+            .Be(enabledInImportedFile);
+    }
+    
+    [Fact]
+    public async Task Gets_Enabled_When_Enabling_Elements_Value_Is_True_And_Logs_Warning_When_Override_Disabled()
+    {
+        const string propsFileContent = @"
+<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+        <EnablePackageVersionOverride>false</EnablePackageVersionOverride>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <PackageVersion Include=""NewtonSoft.Json"" Version=""1.3.3"" />
+    </ItemGroup>
+</Project>";
+        
+        const string targetFile = "C:/some/directory/target.file";
+        var sourceInfo = new SourceInfo();
+        var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { targetFile, new MockFileData("") }, 
+            { "C:/some/Directory.Packages.props", new MockFileData(propsFileContent) }
+        });
+        
+        var context = ArrangeContext<CheckCpmPreprocessor>.Create();
+        context.Use(sourceInfo);
+        context.Use<IFileSystem>(mockFileSystem);
+
+        context
+            .For<ExtractLicensesSettingsBase>()
+            .Setup(settings => settings.GetTargetFile())
+            .Returns(targetFile);
+
+        var sut = context.Build();
+
+        await sut.PreprocessAsync();
+
+        sourceInfo
+            .IsCpmEnabled
+            .Should()
+            .BeTrue();
+        
+        context
+            .For<ILogger>()
+            .Verify(logger => logger.Log(LogLevel.Warning, It.IsAny<string>(), null), Times.Once);
+    }
+}

--- a/src/Core/Liz.Core.Tests/Preparation/CheckCpmPreprocessorTests.cs
+++ b/src/Core/Liz.Core.Tests/Preparation/CheckCpmPreprocessorTests.cs
@@ -1,10 +1,8 @@
 ﻿using ArrangeContext.Moq;
 using FluentAssertions;
-using Liz.Core.Logging.Contracts;
 using Liz.Core.Preparation;
 using Liz.Core.Preparation.Contracts.Models;
 using Liz.Core.Settings;
-using Moq;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using Xunit;
@@ -208,51 +206,5 @@ public sealed class CheckCpmPreprocessorTests
             .IsCpmEnabled
             .Should()
             .Be(enabledInImportedFile);
-    }
-    
-    [Fact]
-    public async Task Gets_Enabled_When_Enabling_Elements_Value_Is_True_And_Logs_Warning_When_Override_Disabled()
-    {
-        const string propsFileContent = @"
-<Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-        <EnablePackageVersionOverride>false</EnablePackageVersionOverride>
-    </PropertyGroup>
-    
-    <ItemGroup>
-        <PackageVersion Include=""NewtonSoft.Json"" Version=""1.3.3"" />
-    </ItemGroup>
-</Project>";
-        
-        const string targetFile = "C:/some/directory/target.file";
-        var sourceInfo = new SourceInfo();
-        var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-        {
-            { targetFile, new MockFileData("") }, 
-            { "C:/some/Directory.Packages.props", new MockFileData(propsFileContent) }
-        });
-        
-        var context = ArrangeContext<CheckCpmPreprocessor>.Create();
-        context.Use(sourceInfo);
-        context.Use<IFileSystem>(mockFileSystem);
-
-        context
-            .For<ExtractLicensesSettingsBase>()
-            .Setup(settings => settings.GetTargetFile())
-            .Returns(targetFile);
-
-        var sut = context.Build();
-
-        await sut.PreprocessAsync();
-
-        sourceInfo
-            .IsCpmEnabled
-            .Should()
-            .BeTrue();
-        
-        context
-            .For<ILogger>()
-            .Verify(logger => logger.Log(LogLevel.Warning, It.IsAny<string>(), null), Times.Once);
     }
 }

--- a/src/Core/Liz.Core/ExtractLicensesFactory.cs
+++ b/src/Core/Liz.Core/ExtractLicensesFactory.cs
@@ -13,6 +13,7 @@ using Liz.Core.PackageReferences.DotnetCli;
 using Liz.Core.PackageReferences.NuGetCli;
 using Liz.Core.Preparation;
 using Liz.Core.Preparation.Contracts;
+using Liz.Core.Preparation.Contracts.Models;
 using Liz.Core.Progress;
 using Liz.Core.Projects;
 using Liz.Core.Result;
@@ -38,6 +39,8 @@ public sealed class ExtractLicensesFactory : IExtractLicensesFactory
         IProgressHandler? progressHandler = null)
     {
         settings.EnsureValidity();
+
+        var sourceInfo = new SourceInfo();
         
         var logger = GetLogger(logLevel, loggerProvider);
         var fileSystem = new FileSystem();
@@ -120,6 +123,7 @@ public sealed class ExtractLicensesFactory : IExtractLicensesFactory
         var downloadPackageReferencesViaDotnetCli = new DownloadPackageReferencesViaDotnetCli(cliToolExecutor);
 
         var downloadPackageReferencesFacade = new DownloadPackageReferencesFacade(
+            sourceInfo,
             provideTemporaryDirectories,
             logger,
             downloadPackageReferencesViaDotnetCli,
@@ -137,6 +141,7 @@ public sealed class ExtractLicensesFactory : IExtractLicensesFactory
 
         var preprocessors = new IPreprocessor[]
         {
+            new CheckCpmPreprocessor(sourceInfo, settings, logger, fileSystem),
             new DeserializeLicenseTypeDefinitionsPreprocessor(settings, logger, fileContentProvider),
             new DeserializeUrlToLicenseTypeMappingPreprocessor(settings, logger, fileContentProvider),
             new DeserializeLicenseTypeWhitelistPreprocessor(settings, logger, fileContentProvider),

--- a/src/Core/Liz.Core/Preparation/CheckCpmPreprocessor.cs
+++ b/src/Core/Liz.Core/Preparation/CheckCpmPreprocessor.cs
@@ -1,11 +1,12 @@
 ﻿using Liz.Core.Logging;
 using Liz.Core.Logging.Contracts;
+using Liz.Core.Preparation.Contracts;
 using Liz.Core.Preparation.Contracts.Models;
 using Liz.Core.Settings;
 using System.IO.Abstractions;
 using System.Xml.Linq;
 
-namespace Liz.Core.Preparation.Contracts;
+namespace Liz.Core.Preparation;
 
 /// <summary>
 ///     preprocessor that checks if the source-code is managed using Central Package Management (CPM) and writes it to the current
@@ -60,10 +61,11 @@ internal sealed class CheckCpmPreprocessor : IPreprocessor
         return candidatePackagesProps != null && IsCpmEnabledThroughPropsFile(candidatePackagesProps);
     }
 
+    // if the file was found we have to check if CPM is actually activated
     private bool IsCpmEnabledThroughPropsFile(IFileInfo propsFile)
     {
-        // if the file was found we have to check if CPM is actually activated
-        var xmlDocument = XDocument.Load(propsFile.FullName);
+        var propsFileContent = _fileSystem.File.ReadAllText(propsFile.FullName);
+        var xmlDocument = XDocument.Parse(propsFileContent);
 
         var enablingElement = xmlDocument.Descendants("ManagePackageVersionsCentrally").FirstOrDefault();
         var versionOverrideElement = xmlDocument.Descendants("EnablePackageVersionOverride").FirstOrDefault();

--- a/src/Core/Liz.Core/Preparation/CheckCpmPreprocessor.cs
+++ b/src/Core/Liz.Core/Preparation/CheckCpmPreprocessor.cs
@@ -68,25 +68,10 @@ internal sealed class CheckCpmPreprocessor : IPreprocessor
         var xmlDocument = XDocument.Parse(propsFileContent);
 
         var enablingElement = xmlDocument.Descendants("ManagePackageVersionsCentrally").FirstOrDefault();
-        var versionOverrideElement = xmlDocument.Descendants("EnablePackageVersionOverride").FirstOrDefault();
         var importElement = xmlDocument.Descendants("Import").FirstOrDefault();
         
         // if we have an enabling element we can check if its available
-        if (enablingElement != null)
-        {
-            if (!enablingElement.Value.ToLower().Equals("true")) return false;
-            
-            /*
-             * NOTE:
-             * when CPM is enabled, but 'EnablePackageVersionOverride' is not, we get problems when downloading packages
-             * that are not in cache, so we'll let the user know!
-             */
-            if (versionOverrideElement?.Value.ToLower().Equals("false") ?? false)
-                _logger.LogWarning("CPM is enabled for the target-file, but 'EnablePackageVersionOverride' is turned off, " +
-                                   "which can lead to problems when trying to download packages that are currently not in cache!");
-
-            return true;
-        }
+        if (enablingElement != null) return enablingElement.Value.ToLower().Equals("true");
 
         // when theres no enabling element and no import (without the proper Attribute), CPM is not enabled!
         var importProject = importElement?.Attribute("Project");

--- a/src/Core/Liz.Core/Preparation/Contracts/CheckCpmPreprocessor.cs
+++ b/src/Core/Liz.Core/Preparation/Contracts/CheckCpmPreprocessor.cs
@@ -1,0 +1,101 @@
+﻿using Liz.Core.Logging;
+using Liz.Core.Logging.Contracts;
+using Liz.Core.Preparation.Contracts.Models;
+using Liz.Core.Settings;
+using System.IO.Abstractions;
+using System.Xml.Linq;
+
+namespace Liz.Core.Preparation.Contracts;
+
+/// <summary>
+///     preprocessor that checks if the source-code is managed using Central Package Management (CPM) and writes it to the current
+///     <see cref="SourceInfo"/> object so that it can be used in other components
+/// </summary>
+internal sealed class CheckCpmPreprocessor : IPreprocessor
+{
+    private readonly SourceInfo _sourceInfo;
+    private readonly ExtractLicensesSettingsBase _settings;
+    private readonly ILogger _logger;
+    private readonly IFileSystem _fileSystem;
+
+    public CheckCpmPreprocessor(
+        SourceInfo sourceInfo,
+        ExtractLicensesSettingsBase settings,
+        ILogger logger,
+        IFileSystem fileSystem)
+    {
+        _sourceInfo = sourceInfo ?? throw new ArgumentNullException(nameof(sourceInfo));
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+    }
+    
+    public Task PreprocessAsync()
+    {
+        var targetFile = _settings.GetTargetFile();
+        var targetFileInfo = _fileSystem.FileInfo.FromFileName(targetFile);
+        var currentDirectory = targetFileInfo.Directory;
+
+        while (currentDirectory != null)
+        {
+            if (IsCpmEnabledInDirectory(currentDirectory))
+            {
+                _logger.LogInformation("CPM is enabled for this target-file!");
+                _sourceInfo.IsCpmEnabled = true;
+                break;
+            }
+            
+            currentDirectory = currentDirectory.Parent;
+        }
+        
+        return Task.CompletedTask;
+    }
+
+    // c.f.: https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management#enabling-central-package-management
+    private bool IsCpmEnabledInDirectory(IDirectoryInfo directoryInfo)
+    {
+        var directoryFiles = directoryInfo.GetFiles();
+        var candidatePackagesProps = directoryFiles.FirstOrDefault(file => file.Name.Equals("Directory.Packages.props"));
+
+        return candidatePackagesProps != null && IsCpmEnabledThroughPropsFile(candidatePackagesProps);
+    }
+
+    private bool IsCpmEnabledThroughPropsFile(IFileInfo propsFile)
+    {
+        // if the file was found we have to check if CPM is actually activated
+        var xmlDocument = XDocument.Load(propsFile.FullName);
+
+        var enablingElement = xmlDocument.Descendants("ManagePackageVersionsCentrally").FirstOrDefault();
+        var versionOverrideElement = xmlDocument.Descendants("EnablePackageVersionOverride").FirstOrDefault();
+        var importElement = xmlDocument.Descendants("Import").FirstOrDefault();
+        
+        // if we have an enabling element we can check if its available
+        if (enablingElement != null)
+        {
+            if (!enablingElement.Value.ToLower().Equals("true")) return false;
+            
+            /*
+             * NOTE:
+             * when CPM is enabled, but 'EnablePackageVersionOverride' is not, we get problems when downloading packages
+             * that are not in cache, so we'll let the user know!
+             */
+            if (versionOverrideElement?.Value.ToLower().Equals("false") ?? false)
+                _logger.LogWarning("CPM is enabled for the target-file, but 'EnablePackageVersionOverride' is turned off, " +
+                                   "which can lead to problems when trying to download packages that are currently not in cache!");
+
+            return true;
+        }
+
+        // when theres no enabling element and no import (without the proper Attribute), CPM is not enabled!
+        var importProject = importElement?.Attribute("Project");
+        if (importProject == null || string.IsNullOrWhiteSpace(importProject.Value)) return false;
+        
+        // we get here when the 'importElement' is not null, so we can follow that to see if something is enabled there...
+        // NOTE: the path in the Attribute is most likely a path relative to the currents file directory we're looking at
+        var importedFilePath = _fileSystem.Path.Combine(propsFile.Directory.FullName, importProject.Value);
+        var importedFile = _fileSystem.FileInfo.FromFileName(importedFilePath);
+        
+        // ReSharper disable once TailRecursiveCall
+        return IsCpmEnabledThroughPropsFile(importedFile);
+    }
+}

--- a/src/Core/Liz.Core/Preparation/Contracts/Models/SourceInfo.cs
+++ b/src/Core/Liz.Core/Preparation/Contracts/Models/SourceInfo.cs
@@ -1,0 +1,15 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Liz.Core.Preparation.Contracts.Models;
+
+/// <summary>
+///     Simple info object containing information about the source code that is currently analyzed
+/// </summary>
+[ExcludeFromCodeCoverage] // simple DTO
+internal sealed class SourceInfo
+{
+    /// <summary>
+    ///     Whether or not the source-code is managed using Central Package Management (CPM)
+    /// </summary>
+    public bool IsCpmEnabled { get; set; }
+}


### PR DESCRIPTION
## 📫 Addressed Issue(s)

- Closes #118 

## 📄 Description

With the newer NuGet versions CPM was introduced which omits the package-versions from the `PackageReference` elements in the `csproj` files. With the current approach of downloading packages that were not found in cache this didnt work, because it is not allowed to use the `Version` attribute in the `PackageReference` element when CPM is enabled.  
For that `VersionOverride` has to be used.  
  
A new preprocessor now checks if CPM is activated for the current sources, if so, the `VersionOverride` attribute will be used when trying to download the missing packages.  
If CPM is enabled and `VersionOverride` is disabled, a warning will be displayed.

## ✅ Checks

- [x] My PR adheres to the general code-style of this project (look at other code if you're unsure)
- ~[ ] My code requires changes to the documentation~
- ~[ ] I have updated the documentation as required~
- [x] All the automated tests have passed
