### PR TITLE
fix: fix system packages not being found

### DIFF
--- a/src/Core/Liz.Core.IntegrationTests/FindPackageReferenceArtifactTests.cs
+++ b/src/Core/Liz.Core.IntegrationTests/FindPackageReferenceArtifactTests.cs
@@ -14,10 +14,10 @@ public class FindPackageReferenceArtifactTests
     [InlineData("abc", "1.33.7", false)]
     public async Task Finds_Package_Reference_Artifact(string packageName, string packageVersion, bool expectedOutcome)
     {
+        var fileSystem = new FileSystem();
         var logger = new Logging.Null.NullLogger();
         var cliExecutor = new DefaultCliToolExecutor(logger);
-        var provideNugetCaches = new ProvideNugetCacheDirectories(cliExecutor);
-        var fileSystem = new FileSystem();
+        var provideNugetCaches = new ProvideNugetCacheDirectories(cliExecutor, fileSystem);
 
         var findPackageReferenceArtifact = new FindPackageReferenceArtifact(provideNugetCaches, fileSystem, logger);
 

--- a/src/Core/Liz.Core.Tests/Utils/ProvideNugetCacheDirectoriesTests.cs
+++ b/src/Core/Liz.Core.Tests/Utils/ProvideNugetCacheDirectoriesTests.cs
@@ -3,6 +3,8 @@ using FluentAssertions;
 using Liz.Core.CliTool.Contracts;
 using Liz.Core.Utils;
 using Moq;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
 using Xunit;
 
 namespace Liz.Core.Tests.Utils;
@@ -13,6 +15,8 @@ public class ProvideNugetCacheDirectoriesTests
     public async Task Provides_Cache_Directories()
     {
         var context = ArrangeContext<ProvideNugetCacheDirectories>.Create();
+        context.Use<IFileSystem>(new MockFileSystem());
+        
         var sut = context.Build();
 
         const string expectedDirectory = @"C:\Users\some-user\.nuget\packages\";
@@ -26,7 +30,7 @@ public class ProvideNugetCacheDirectoriesTests
 
         result
             .Should()
-            .OnlyContain(directory => directory == expectedDirectory);
+            .Contain(directory => directory == expectedDirectory);
 
         // getting the directory should be cached, so a second call should just return the cache
         _ = await sut.GetAsync();

--- a/src/Core/Liz.Core/ExtractLicensesFactory.cs
+++ b/src/Core/Liz.Core/ExtractLicensesFactory.cs
@@ -111,7 +111,7 @@ public sealed class ExtractLicensesFactory : IExtractLicensesFactory
             new ExportLicenseTextsResultProcessor(settings, fileSystem)
         };
 
-        var provideNugetCacheDirectories = new ProvideNugetCacheDirectories(cliToolExecutor);
+        var provideNugetCacheDirectories = new ProvideNugetCacheDirectories(cliToolExecutor, fileSystem);
         var findPackageReferenceArtifact = new FindPackageReferenceArtifact(
             provideNugetCacheDirectories,
             fileSystem,


### PR DESCRIPTION
## 📫 Addressed Issue(s)

none

## 📄 Description

i realized that sometimes System packages are not being considered or found. Added a new cache directory which contains offline packages of an SDK installation which should help.

## ✅ Checks

- [x] My PR adheres to the general code-style of this project (look at other code if you're unsure)
- ~[ ] My code requires changes to the documentation~
- ~[ ] I have updated the documentation as required~
- [x] All the automated tests have passed
