### PR TITLE
fix: fix missing packages when sdk-style-project has project-reference to non-sdk-style-project

### DIFF
--- a/src/Core/Liz.Core.IntegrationTests/ExtractLicensesTests.cs
+++ b/src/Core/Liz.Core.IntegrationTests/ExtractLicensesTests.cs
@@ -1,0 +1,47 @@
+﻿using FluentAssertions;
+using Liz.Core.Logging.Null;
+using Liz.Core.Settings;
+using Xunit;
+
+namespace Liz.Core.IntegrationTests;
+
+public sealed class ExtractLicensesTests
+{
+    [Fact] // c.f.: https://github.com/wgnf/liz/issues/116
+    public async Task Extract_Licenses_From_Sdk_Style_Project_Which_Has_A_Reference_To_An_Old_Style_Project()
+    {
+        var factory = new ExtractLicensesFactory();
+        // this test-project has a project-reference to an old-style-project
+        // NOTE: This path might have to be adjusted for other developers
+        var settings = new ExtractLicensesSettings("../../../../../../test-data/sln/SdkStyleProject/SdkStyleProject.csproj")
+        {
+            // this problem is only apparent when we're including transitive dependencies, which include projects too
+            IncludeTransitiveDependencies = true
+        };
+        
+        var sut = factory.Create(settings, new NullLoggerProvider());
+
+        var packageReferences = await sut.ExtractAsync();
+
+        packageReferences
+            .Should()
+            .Contain(packageReference =>
+                packageReference.Name == "Microsoft.Bcl" ||
+                packageReference.Name == "Microsoft.Bcl.Build");
+    }
+
+    private class ExtractLicensesSettings : ExtractLicensesSettingsBase
+    {
+        private readonly string _targetFile;
+
+        public ExtractLicensesSettings(string targetFile)
+        {
+            _targetFile = targetFile;
+        }
+        
+        public override string GetTargetFile()
+        {
+            return _targetFile;
+        }
+    }
+}

--- a/src/Core/Liz.Core.Tests/PackageReferences/DotnetCli/GetPackageReferencesViaDotnetCliTests.cs
+++ b/src/Core/Liz.Core.Tests/PackageReferences/DotnetCli/GetPackageReferencesViaDotnetCliTests.cs
@@ -86,8 +86,8 @@ public class GetPackageReferencesViaDotnetCliTests
             .Setup(getProjectReferences => getProjectReferences.Get(It.IsAny<Project>()))
             .Returns(new[]
             {
-                new ProjectReference("liz.something"),
-                new ProjectReference("liz.core.something")
+                new ProjectReference("liz.something", "liz.something.csproj"),
+                new ProjectReference("liz.core.something", "liz.core.something.csproj")
             });
         
         var project = new Project("Something", Mock.Of<IFileInfo>(), ProjectFormatStyle.SdkStyle);

--- a/src/Core/Liz.Core/ExtractLicensesFactory.cs
+++ b/src/Core/Liz.Core/ExtractLicensesFactory.cs
@@ -47,11 +47,11 @@ public sealed class ExtractLicensesFactory : IExtractLicensesFactory
         var cliToolExecutor = new DefaultCliToolExecutor(logger);
         var httpClient = new HttpClientWrapper();
         var fileContentProvider = new FileContentProvider(fileSystem, httpClient);
+        var getProjectReferences = new GetProjectReferences(fileSystem);
 
-        var getProjects = new GetProjectsViaSlnParser(new SolutionParser(), fileSystem);
+        var getProjects = new GetProjectsViaSlnParser(settings, new SolutionParser(), fileSystem, getProjectReferences);
         var parseDotnetListPackage = new ParseDotnetListPackageResult();
         var parsePackagesConfigFile = new ParsePackagesConfigFile();
-        var getProjectReferences = new GetProjectReferences(fileSystem);
 
         var getPackageReferencesDotnetCli = new GetPackageReferencesViaDotnetCli(
             cliToolExecutor, 

--- a/src/Core/Liz.Core/Projects/Contracts/Models/ProjectReference.cs
+++ b/src/Core/Liz.Core/Projects/Contracts/Models/ProjectReference.cs
@@ -7,15 +7,20 @@ internal sealed class ProjectReference : IEquatable<ProjectReference>
 {
     private readonly List<ProjectReference> _projectReferences = new();
 
-    public ProjectReference(string name)
+    public ProjectReference(string name, string fileName)
     {
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException("Value cannot be null or whitespace.", nameof(name));
+        if (string.IsNullOrWhiteSpace(fileName))
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(fileName));
 
         Name = name;
+        FileName = fileName;
     }
 
     public string Name { get; }
+    
+    public string FileName { get; }
 
     public IEnumerable<ProjectReference> ProjectReferences => _projectReferences;
 

--- a/src/Core/Liz.Core/Projects/GetProjectReferences.cs
+++ b/src/Core/Liz.Core/Projects/GetProjectReferences.cs
@@ -32,7 +32,8 @@ internal sealed class GetProjectReferences : IGetProjectReferences
 
     private ProjectReference DoGetProjectReference(IFileInfo projectFile)
     {
-        var projectFileContent = _fileSystem.File.ReadAllText(projectFile.FullName);
+        var projectFileName = projectFile.FullName;
+        var projectFileContent = _fileSystem.File.ReadAllText(projectFileName);
         var projectReferenceName = DetermineProjectReferenceName(projectFileContent, projectFile);
 
         // if something is in the (local class-)cache, we don't have to run the whole thing again
@@ -40,7 +41,7 @@ internal sealed class GetProjectReferences : IGetProjectReferences
             .FirstOrDefault(reference => reference.Name == projectReferenceName);
         if (cachedCandidate != null) return cachedCandidate;
 
-        var currentProjectReference = new ProjectReference(projectReferenceName);
+        var currentProjectReference = new ProjectReference(projectReferenceName, projectFileName);
         var subProjectReferenceFiles = DetermineSubProjectReferenceFiles(projectFileContent, projectFile);
 
         foreach (var subProjectReferenceFile in subProjectReferenceFiles)


### PR DESCRIPTION
## 📫 Addressed Issue(s)

- Closes #116 

## 📄 Description

This bug was observed a long time ago. When an SDK-Style-Project has a project-reference to a Non-SDK-Style project, and one starts analysing the SDK-Style-Project with `IncludeTransitiveDependencies` turned on, the package-references in the Non-SDK-Style project are not included.

## ✅ Checks

- [x] My PR adheres to the general code-style of this project (look at other code if you're unsure)
- ~[ ] My code requires changes to the documentation~
- ~[ ] I have updated the documentation as required~
- [x] All the automated tests have passed
