### PR TITLE
fix: make a package-references Name and Version case-insensitive

### DIFF
--- a/src/Core/Liz.Core/PackageReferences/Contracts/Models/PackageReference.cs
+++ b/src/Core/Liz.Core/PackageReferences/Contracts/Models/PackageReference.cs
@@ -91,7 +91,7 @@ public sealed class PackageReference : IEquatable<PackageReference>
     {
         if (ReferenceEquals(null, other)) return false;
         if (ReferenceEquals(this, other)) return true;
-        return Name == other.Name && Version == other.Version;
+        return string.Equals(Name, other.Name, StringComparison.InvariantCultureIgnoreCase) && string.Equals(Version, other.Version, StringComparison.InvariantCultureIgnoreCase);
     }
 
     /// <inheritdoc />
@@ -103,7 +103,10 @@ public sealed class PackageReference : IEquatable<PackageReference>
     /// <inheritdoc />
     public override int GetHashCode()
     {
-        return HashCode.Combine(Name, Version);
+        var hashCode = new HashCode();
+        hashCode.Add(Name, StringComparer.InvariantCultureIgnoreCase);
+        hashCode.Add(Version, StringComparer.InvariantCultureIgnoreCase);
+        return hashCode.ToHashCode();
     }
 
     /// <summary>


### PR DESCRIPTION
## 📫 Addressed Issue(s)

- Closes #117 

## 📄 Description

I've seen `NUnit` and `nunit` being included in another project. This is not right. Package-references Name and Version are treated case-insensitive so _liz_ should to the same!

## ✅ Checks

- [x] My PR adheres to the general code-style of this project (look at other code if you're unsure)
- ~[ ] My code requires changes to the documentation~
- ~[ ] I have updated the documentation as required~
- [x] All the automated tests have passed
